### PR TITLE
Set up development package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ buck-out/
 web-build/
 
 # @end expo-cli
+
+settings.json

--- a/path_to_toolkit
+++ b/path_to_toolkit
@@ -1,0 +1,1 @@
+path_to_toolkit

--- a/shell/latest/metro.config.js
+++ b/shell/latest/metro.config.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const MetroUtils = require('@npe/config/MetroUtils');
+const MetroUtils = require('@npe-toolkit-tools/config/MetroUtils');
 const { getDefaultConfig } = require('expo/metro-config');
 
 module.exports = MetroUtils.metroWithLocalDeps(__dirname, getDefaultConfig(__dirname));

--- a/shell/latest/package.json
+++ b/shell/latest/package.json
@@ -51,7 +51,6 @@
     "react-native-screens": "~3.15.0",
     "react-native-svg": "12.3.0",
     "react-native-url-polyfill": "^1.3.0",
-    "react-native-videoeditorsdk": "^2.15.0",
     "react-native-web": "^0.18.0",
     "react-native-web-webview": "^1.0.2",
     "react-native-webview": "11.23.0",
@@ -59,24 +58,7 @@
     "uuid": "^3.4.0"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
-    "@babel/plugin-proposal-optional-chaining": "^7.18.9",
-    "@babel/plugin-transform-arrow-functions": "^7.18.6",
-    "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-    "@babel/plugin-transform-shorthand-properties": "^7.18.6",
-    "@babel/plugin-transform-template-literals": "^7.18.9",
-    "@babel/preset-typescript": "^7.18.6",
-    "@expo/webpack-config": "^0.15.0",
-    "@npe/config": "file:../../tools/config",
-    "@types/react": "18.0.0",
-    "@types/react-dom": "18.0.0",
-    "@types/react-native": "0.69.6",
-    "babel-plugin-transform-typescript-metadata": "^0.3.2",
-    "plist": "^3.0.4",
-    "typescript": "4.5.5",
-    "webpack-dev-server": "^3.11.0",
-    "xcode": "^3.0.1"
+    "@npe-toolkit-tools": "file:../../tools"
   },
   "localDependencies": {
     "@toolkit": "../../lib",

--- a/shell/latest/yarn.lock
+++ b/shell/latest/yarn.lock
@@ -16,7 +16,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz"
   integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
@@ -45,7 +45,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.1.tgz#f2e6ef7790d8c8dbf03d379502dcc246dcce0b30"
   integrity sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==
 
-"@babel/core@7.9.0", "@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.14.0", "@babel/core@^7.17.5", "@babel/core@^7.7.5":
+"@babel/core@7.9.0", "@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.14.0", "@babel/core@^7.17.5", "@babel/core@^7.7.5", "@babel/core@~7.9.0":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.9.tgz#6bae81a06d95f4d0dec5bb9d74bbc1f58babdcfe"
   integrity sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==
@@ -66,27 +66,26 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/core@~7.9.0":
-  version "7.9.6"
-  resolved "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz"
-  integrity sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==
+"@babel/core@^7.12.9":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.20.5.tgz#45e2114dc6cd4ab167f81daf7820e8fa1250d113"
+  integrity sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==
   dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.9.6"
-    "@babel/helper-module-transforms" "^7.9.0"
-    "@babel/helpers" "^7.9.6"
-    "@babel/parser" "^7.9.6"
-    "@babel/template" "^7.8.6"
-    "@babel/traverse" "^7.9.6"
-    "@babel/types" "^7.9.6"
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.20.5"
+    "@babel/helper-compilation-targets" "^7.20.0"
+    "@babel/helper-module-transforms" "^7.20.2"
+    "@babel/helpers" "^7.20.5"
+    "@babel/parser" "^7.20.5"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.20.5"
+    "@babel/types" "^7.20.5"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
-    json5 "^2.1.2"
-    lodash "^4.17.13"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.1"
+    semver "^6.3.0"
 
 "@babel/generator@^7.14.0", "@babel/generator@^7.20.1":
   version "7.20.1"
@@ -97,7 +96,7 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/generator@^7.17.0", "@babel/generator@^7.9.6":
+"@babel/generator@^7.17.0":
   version "7.17.0"
   resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz"
   integrity sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==
@@ -130,6 +129,15 @@
   integrity sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==
   dependencies:
     "@babel/types" "^7.18.10"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.5.tgz#cb25abee3178adf58d6814b68517c62bdbfdda95"
+  integrity sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==
+  dependencies:
+    "@babel/types" "^7.20.5"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
@@ -183,7 +191,7 @@
     browserslist "^4.17.5"
     semver "^6.3.0"
 
-"@babel/helper-compilation-targets@^7.18.9", "@babel/helper-compilation-targets@^7.19.0", "@babel/helper-compilation-targets@^7.19.3":
+"@babel/helper-compilation-targets@^7.18.9", "@babel/helper-compilation-targets@^7.19.0", "@babel/helper-compilation-targets@^7.19.3", "@babel/helper-compilation-targets@^7.20.0":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz#6bf5374d424e1b3922822f1d9bdaa43b1a139d0a"
   integrity sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==
@@ -382,7 +390,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-module-transforms@^7.16.7", "@babel/helper-module-transforms@^7.9.0":
+"@babel/helper-module-transforms@^7.16.7":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz"
   integrity sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==
@@ -423,6 +431,20 @@
     "@babel/template" "^7.18.10"
     "@babel/traverse" "^7.19.6"
     "@babel/types" "^7.19.4"
+
+"@babel/helper-module-transforms@^7.20.2":
+  version "7.20.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz#ac53da669501edd37e658602a21ba14c08748712"
+  integrity sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.20.2"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.20.1"
+    "@babel/types" "^7.20.2"
 
 "@babel/helper-optimise-call-expression@^7.16.7":
   version "7.16.7"
@@ -517,6 +539,13 @@
   dependencies:
     "@babel/types" "^7.19.4"
 
+"@babel/helper-simple-access@^7.20.2":
+  version "7.20.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz#0ab452687fe0c2cfb1e2b9e0015de07fc2d62dd9"
+  integrity sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==
+  dependencies:
+    "@babel/types" "^7.20.2"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz"
@@ -599,14 +628,14 @@
     "@babel/traverse" "^7.17.9"
     "@babel/types" "^7.17.0"
 
-"@babel/helpers@^7.9.6":
-  version "7.17.0"
-  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.0.tgz"
-  integrity sha512-Xe/9NFxjPwELUvW2dsukcMZIp6XwPSbI4ojFBJuX5ramHuVE22SVcZIwqzdWo5uCgeTXW8qV97lMvSOjq+1+nQ==
+"@babel/helpers@^7.20.5":
+  version "7.20.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.6.tgz#e64778046b70e04779dfbdf924e7ebb45992c763"
+  integrity sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==
   dependencies:
-    "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.17.0"
-    "@babel/types" "^7.17.0"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.20.5"
+    "@babel/types" "^7.20.5"
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
   version "7.16.10"
@@ -636,7 +665,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.1.tgz#3e045a92f7b4623cafc2425eddcb8cf2e54f9cc5"
   integrity sha512-hp0AYxaZJhxULfM1zyp7Wgr+pSUKBcP3M+PHnSzWGdXOzg/kHWIgiUWARvubhUKGOEw3xqY4x+lyZ9ytBVcELw==
 
-"@babel/parser@^7.16.7", "@babel/parser@^7.17.0", "@babel/parser@^7.9.6":
+"@babel/parser@^7.16.7", "@babel/parser@^7.17.0":
   version "7.17.0"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz"
   integrity sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==
@@ -650,6 +679,11 @@
   version "7.19.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.3.tgz#8dd36d17c53ff347f9e55c328710321b49479a9a"
   integrity sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==
+
+"@babel/parser@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.5.tgz#7f3c7335fe417665d929f34ae5dceae4c04015e8"
+  integrity sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1687,7 +1721,7 @@
   dependencies:
     regenerator-runtime "^0.13.10"
 
-"@babel/template@^7.0.0", "@babel/template@^7.16.7", "@babel/template@^7.3.3", "@babel/template@^7.8.6":
+"@babel/template@^7.0.0", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz"
   integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
@@ -1721,7 +1755,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.17.0", "@babel/traverse@^7.9.6":
+"@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7":
   version "7.17.0"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz"
   integrity sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==
@@ -1785,7 +1819,23 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.9.6":
+"@babel/traverse@^7.20.1", "@babel/traverse@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.5.tgz#78eb244bea8270fdda1ef9af22a5d5e5b7e57133"
+  integrity sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.20.5"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.20.5"
+    "@babel/types" "^7.20.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/types@^7.0.0", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.17.0"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz"
   integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
@@ -1806,6 +1856,15 @@
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.0.tgz#52c94cf8a7e24e89d2a194c25c35b17a64871479"
   integrity sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.20.2", "@babel/types@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.5.tgz#e206ae370b5393d94dfd1d04cd687cace53efa84"
+  integrity sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
     "@babel/helper-validator-identifier" "^7.19.1"
@@ -1955,7 +2014,7 @@
     xcode "^3.0.1"
     xml2js "^0.4.23"
 
-"@expo/config-plugins@^4.0.14", "@expo/config-plugins@^4.0.9":
+"@expo/config-plugins@^4.0.14":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.1.5.tgz#9d357d2cda9c095e511b51583ede8a3b76174068"
   integrity sha512-RVvU40RtZt12HavuDAe+LDIq9lHj7sheOfMEHdmpJ/uTA8pgvkbc56XF6JHQD+yRr6+uhhb+JnAasGq49dsQbw==
@@ -2060,7 +2119,7 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/dev-server@~0.1.120":
+"@expo/dev-server@0.1.120", "@expo/dev-server@~0.1.120":
   version "0.1.120"
   resolved "https://registry.yarnpkg.com/@expo/dev-server/-/dev-server-0.1.120.tgz#0c7aff4e29d98298214129127f5df951cb7b81dd"
   integrity sha512-x5/jCv0EOpz6FyehXpI5bgDQTVsGZYvgISkAw7n60RhtG+aid6N2CCR9SDMCH70XaUpFnfTW9qvderpCEj7Puw==
@@ -2920,8 +2979,28 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@npe/config@file:../../tools/config":
-  version "0.0.1"
+"@npe-toolkit-tools@file:../../tools":
+  version "1.0.0"
+  dependencies:
+    "@babel/core" "~7.9.0"
+    "@babel/plugin-proposal-class-properties" "^7.18.6"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.18.6"
+    "@babel/plugin-proposal-optional-chaining" "^7.18.9"
+    "@babel/plugin-transform-arrow-functions" "^7.18.6"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.18.6"
+    "@babel/plugin-transform-template-literals" "^7.18.9"
+    "@babel/preset-typescript" "^7.18.6"
+    "@expo/dev-server" "0.1.120"
+    "@expo/webpack-config" "^0.15.0"
+    "@types/react" "18.0.0"
+    "@types/react-dom" "18.0.0"
+    "@types/react-native" "0.69.6"
+    babel-plugin-transform-typescript-metadata "^0.3.2"
+    plist "^3.0.4"
+    typescript "4.5.5"
+    webpack-dev-server "^3.11.0"
+    xcode "^3.0.1"
 
 "@npmcli/fs@^1.0.0":
   version "1.1.1"
@@ -6536,10 +6615,10 @@ expo-modules-autolinking@0.10.3, expo-modules-autolinking@~0.10.1:
     find-up "^5.0.0"
     fs-extra "^9.1.0"
 
-expo-modules-core@0.11.8:
-  version "0.11.8"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-0.11.8.tgz#68de1bc56a148b9a9c03f1268c67e9e264d4d4b9"
-  integrity sha512-goC2ghZFVaV6nXEbk+kz9oKnQmqW8fHVUCSPxC0QXhV0ay1dA9Ki6qqMPagkBJUPAz89NsNqW3bYR6DFXq7lvA==
+expo-modules-core@0.11.9:
+  version "0.11.9"
+  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-0.11.9.tgz#43763bca72b72f268ad5d7f1f0fc1c7cc75a6e9f"
+  integrity sha512-6AlOE4KHN3/WWbY8hH7W6ceuIFj0qbk1N+UhmMhiCEUas3NvXA6wcH3xjO+8JZ+BRcIB9M4QEeX72j6vDDuExg==
   dependencies:
     compare-versions "^3.4.0"
     invariant "^2.2.4"
@@ -6620,10 +6699,10 @@ expo-updates@~0.14.6:
     resolve-from "^5.0.0"
     uuid "^3.4.0"
 
-expo@~46.0.16:
-  version "46.0.16"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-46.0.16.tgz#8fe6d10207dabda34a684efac2c45c3c1c089f11"
-  integrity sha512-lZETkf3t+gbZjKjSceIpU7I8Rmm5nZ0ZG1WPzNBBbm+k64/+kKV96s6RqS37W1TTDpIbd+AucT9kKpvtv0JB2A==
+expo@~46.0.17:
+  version "46.0.17"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-46.0.17.tgz#d558aa11056007269d2a38481982f1ebbe0852f3"
+  integrity sha512-rB+KMvjU3lFMkec5LcVFFn0Q2iJUEIoyB9TckKMirA15H5mW4yZMao0ilR7239fJ5ytVoDC8SIf7ZAvTmiMuMw==
   dependencies:
     "@babel/runtime" "^7.14.0"
     "@expo/cli" "0.3.2"
@@ -6637,7 +6716,7 @@ expo@~46.0.16:
     expo-font "~10.2.1"
     expo-keep-awake "~10.2.0"
     expo-modules-autolinking "0.10.3"
-    expo-modules-core "0.11.8"
+    expo-modules-core "0.11.9"
     fbemitter "^3.0.0"
     getenv "^1.0.0"
     invariant "^2.2.4"
@@ -7169,7 +7248,7 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -11446,13 +11525,6 @@ react-native-gradle-plugin@^0.0.7:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz#96602f909745239deab7b589443f14fce5da2056"
   integrity sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==
 
-react-native-imglysdk@2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/react-native-imglysdk/-/react-native-imglysdk-2.15.0.tgz#ca798e2964f73ded508b2705bab4aec0f39aea22"
-  integrity sha512-I5rtYl4xELV8TpjpSJQO/u9ALC0bdhC/Z1W+A2IS4Gb0Drx4SsA/7qu/ZxZP93PmPumv923YhcwDJZfY6LWo/g==
-  dependencies:
-    "@expo/config-plugins" "^4.0.9"
-
 react-native-iphone-x-helper@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz"
@@ -11508,13 +11580,6 @@ react-native-url-polyfill@^1.3.0:
   integrity sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==
   dependencies:
     whatwg-url-without-unicode "8.0.0-3"
-
-react-native-videoeditorsdk@^2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/react-native-videoeditorsdk/-/react-native-videoeditorsdk-2.15.0.tgz#2ce78ada25547cecd0844cba291240538e62bc54"
-  integrity sha512-S0Fw1QdEbL83ptGM6hyVHd7/gVx0SnPHe5k0FNW+33tIRDldbyvwn1pMKyuklzk8yYumqHCKsuLDpTwLZbgQKw==
-  dependencies:
-    react-native-imglysdk "2.15.0"
 
 react-native-web-webview@^1.0.2:
   version "1.0.2"
@@ -11902,7 +11967,7 @@ resolve@^1.10.0, resolve@^1.13.1, resolve@^1.18.1:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^1.14.2, resolve@^1.3.2:
+resolve@^1.14.2:
   version "1.22.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -12119,7 +12184,7 @@ selfsigned@^1.10.8:
   dependencies:
     node-forge "^0.10.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==

--- a/templates/faves/package.json
+++ b/templates/faves/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "npe-toolkit-faves",
-    "version": "0.0.1",
-    "scripts": {
-        "postinstall": "cd project && yarn install"
-    }
+  "name": "npe-toolkit-faves",
+  "version": "0.0.1",
+  "scripts": {
+    "postinstall": "cd project && ./setup.sh"
+  }
 }

--- a/templates/faves/project/index.js
+++ b/templates/faves/project/index.js
@@ -6,4 +6,4 @@
  */
 
 // TODO: Make this configurable
-require('../../faves/client/index');
+require('../client/index');

--- a/templates/faves/project/metro.config.js
+++ b/templates/faves/project/metro.config.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const MetroUtils = require('@npe/config/MetroUtils');
+const MetroUtils = require('@npe-toolkit-tools/config/MetroUtils');
 const { getDefaultConfig } = require('expo/metro-config');
 
 module.exports = MetroUtils.metroWithLocalDeps(__dirname, getDefaultConfig(__dirname));

--- a/templates/faves/project/package.json
+++ b/templates/faves/project/package.json
@@ -6,17 +6,17 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@toolkit/shell/latest": "file:../../../shell/latest"
+    "@npe-toolkit-shell": "file:/usr/local/lib/npe-toolkit/shell/latest"
   },
   "devDependencies": {
-    "@toolkit/shell/latest/dev": "file:../../../shell/latest/dev"
+    "@npe-toolkit-tools": "file:/usr/local/lib/npe-toolkit/tools"
   },
   "resolutions": {
     "**/@babel/core": "^7.17.5",
     "**/chokidar": "^3.1.4"
   },
   "localDependencies": {
-    "@toolkit": "../../../lib",
+    "@toolkit": "/usr/local/lib/.npe-toolkit/lib",
     "app": "../client",
     "hax-app-common": "../common"
   },

--- a/templates/faves/project/setup.sh
+++ b/templates/faves/project/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Script to set up a new project directory
+
+# Currently just verifies that there is a symlink at `/usr/local/lib/npe-toolkit`
+# and prints a message to set up symlink if not
+
+NPE_TOOLKIT_SYMLINK=/usr/local/lib/npe-toolkit
+
+if [[ ! -d $NPE_TOOLKIT_SYMLINK ]]; then
+    echo ERROR: You need to symlink npe-toolkit when using developer build
+    echo "> ln -s path_to_toolkit /usr/local/lib/npe-toolkit"
+    exit 1
+fi
+
+yarn install

--- a/templates/faves/project/webpack.config.js
+++ b/templates/faves/project/webpack.config.js
@@ -11,7 +11,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
-const WebpackUtils = require('@npe/config/WebpackUtils');
+const WebpackUtils = require('@npe-toolkit-tools/config/WebpackUtils');
 
 WebpackUtils.testConsoleLog();
 

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "npe-toolkit-shell-dev-deps",
+  "name": "npe-toolkit-tools",
   "version": "1.0.0",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -13,7 +13,6 @@
     "@babel/preset-typescript": "^7.18.6",
     "@expo/dev-server": "0.1.120",
     "@expo/webpack-config": "^0.15.0",
-    "@npe/config": "file:../../../tools/config",
     "@types/react": "18.0.0",
     "@types/react-dom": "18.0.0",
     "@types/react-native": "0.69.6",

--- a/tools/templates/test.sh
+++ b/tools/templates/test.sh
@@ -5,24 +5,30 @@ UUID=$(uuidgen)
 TRASH_DIR=~/.Trash/$UUID
 TEMPLATE_DIR=../../templates/faves
 APP_NAME=test-app
+NPE_TOOLKIT_SYMLINK=/usr/local/lib/npe-toolkit
 
 mkdir $TRASH_DIR
 
 function removeDir() {
     if [[ -d $1 ]]; then
         echo Moving generated files to trash: $1
-        mv $1 $TRASH_DIR/$2
+        rm -rf $1
     fi
 }
 
-echo ---\\nRemoving previous installation \(if any\)\\n---
+echo --- Removing previous installation \(if any\) ---
 removeDir $APP_NAME $APP_NAME
 removeDir $TEMPLATE_DIR/project/node_modules node_modules
 removeDir $TEMPLATE_DIR/project/.expo .expo
+echo --- End removing previous installation ---
 
-# TODO: Configure toolkit path with environment variable, e.g. TK=path/to/tk
-# DEBUG env variable turns on debugging for `create-expo-app`
-DEBUG=expo:init:template yarn create expo-app $APP_NAME -t $TEMPLATE_DIR
+if [[ ! -d $NPE_TOOLKIT_SYMLINK ]]; then
+    echo Symlinking toolkit to the root of this NPE Toolkit dev tree
+    sudo ln -s $(readlink -f ../../) $NPE_TOOLKIT_SYMLINK
+fi
+
+# Note: Prefix with `DEBUG=expo:init:template` to turn on debugging for `create-expo-app`
+yarn create expo-app $APP_NAME -t $TEMPLATE_DIR
 
 # There appears to be a bug in
 # https://github.com/expo/expo-cli/blob/main/packages/create-expo-app/src/utils/git.ts


### PR DESCRIPTION
Sets up development package structure:
- @npe-toolkit-shell points at the shell
- @npe-toolkit-tools points at all tools and devDependencies
- @toolkit points at the library

In development mode, uses a symlink to /usr/local/lib/npe-toolkit to allow for development of toolkit in a separate repository from the app.

For full release, these will be turned into separate NPM packges.