### PR TITLE
Better link instructions for Google auth Client IDs

### DIFF
--- a/templates/faves/common/Config.tsx
+++ b/templates/faves/common/Config.tsx
@@ -39,7 +39,7 @@ export const FIREBASE_CONFIG: FirebaseConfig = localConf['firebase'] ?? {
 
 /**
  * Fill in the client IDs from
- * https://console.cloud.google.com/apis/credentials?project=YOUR_PROJECT
+ * https://console.cloud.google.com/apis/credentials (choose your project from dropdown)
  *
  * You also will need to add redirect URIs in the console, see
  * https://github.com/facebookincubator/npe-toolkit/blob/main/docs/getting-started/Firebase.md


### PR DESCRIPTION
Better link instructions for Google auth Client IDs

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/36).
* #44
* #43
* #42
* #41
* #40
* #39
* #38
* #37
* __->__ #36