### PR TITLE
Don't show error when user cancels login

### DIFF
--- a/lib/core/api/Login.tsx
+++ b/lib/core/api/Login.tsx
@@ -19,6 +19,7 @@
  */
 
 import {AuthType, LoginCredential, TryConnectFn} from '@toolkit/core/api/Auth';
+import {CodedErrorFor} from '@toolkit/core/util/CodedError';
 
 const IdentityService = {
   // Sets a provider. Will overwrite any existing providers for that type
@@ -136,6 +137,16 @@ function getDevIdentityInfo(): LoginCredential | null {
       }
     : null;
 }
+
+/**
+ * Login errors. It is important to add specific login errors for cases that require special handling,
+ * as the client will need to inspect the CodedError to verify
+ */
+export const LoginError = CodedErrorFor('auth.login_fail', 'Error logging in');
+export const UserCanceledLogin = CodedErrorFor(
+  'auth.user_canceled',
+  'User canceled login',
+);
 
 /**
  * Generic API for identity providers. This won't work for all use cases, as some auth

--- a/lib/core/util/CodedError.tsx
+++ b/lib/core/util/CodedError.tsx
@@ -48,6 +48,10 @@ export function CodedErrorFor(
   return errorFn;
 }
 
+export function isErrorType(e: any, codedErrorType: {type: string}) {
+  return e instanceof CodedError && e.type === codedErrorType.type;
+}
+
 const DEFAULT_ERROR_TEXT = 'Unknown failure';
 
 /**

--- a/lib/screens/login/LoginScreen.tsx
+++ b/lib/screens/login/LoginScreen.tsx
@@ -13,8 +13,9 @@ import {useNavigation, useRoute} from '@react-navigation/native';
 import Markdown from 'react-native-markdown-display';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {AuthType, useAuth} from '@toolkit/core/api/Auth';
+import {UserCanceledLogin} from '@toolkit/core/api/Login';
 import {useAppInfo, useTheme} from '@toolkit/core/client/Theme';
-import {toUserMessage} from '@toolkit/core/util/CodedError';
+import {isErrorType, toUserMessage} from '@toolkit/core/util/CodedError';
 import {Opt} from '@toolkit/core/util/Types';
 import {
   FacebookButton,
@@ -112,8 +113,10 @@ export function AuthenticationButtons(props: {
       await auth.login(creds);
       navigate(next);
     } catch (e) {
-      console.log(e);
-      setLoginErrorMessage(toUserMessage(e));
+      console.log('Error in login flow', e);
+      if (!isErrorType(e, UserCanceledLogin)) {
+        setLoginErrorMessage(toUserMessage(e));
+      }
     }
   }
 


### PR DESCRIPTION
Don't show error when user cancels login

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/59).
* #63
* #62
* #61
* #60
* __->__ #59