### PR TITLE
Unify implementation of useData() and useApi()

### DIFF
--- a/lib/providers/firebase/client/FunctionsApi.tsx
+++ b/lib/providers/firebase/client/FunctionsApi.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Api, ApiKey, createApiKey} from '@toolkit/core/api/DataApi';
+import {Api, ApiKey, createApiKey, useData} from '@toolkit/core/api/DataApi';
 import {BOOL, useStored} from '@toolkit/core/client/Storage';
 import {useAppConfig} from '@toolkit/core/util/AppConfig';
 import {CodedError} from '@toolkit/core/util/CodedError';
@@ -31,7 +31,11 @@ export function useEmulator() {
   return useStored(USE_EMULATOR_KEY, BOOL, false);
 }
 
-export function useApi<I, O>(apiKey: ApiKey<I, O>): Api<I, O> {
+export function useApi<I, O>(key: ApiKey<I, O>) {
+  return useData(key);
+}
+
+export function firebaseFn<I, O>(key: ApiKey<I, O>) {
   const appConfig = useAppConfig();
   const firebaseConfig = getFirebaseConfig();
   const instance = getInstanceFor(appConfig);
@@ -51,7 +55,7 @@ export function useApi<I, O>(apiKey: ApiKey<I, O>): Api<I, O> {
     }
 
     try {
-      const result = await functions.httpsCallable(prefix + apiKey.id)(input);
+      const result = await functions.httpsCallable(prefix + key.id)(input);
       return result.data as O;
     } catch (e: any) {
       throw toCodedError(e) || e;

--- a/templates/faves/common/Api.tsx
+++ b/templates/faves/common/Api.tsx
@@ -5,28 +5,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {createApiKey} from '@toolkit/core/api/DataApi';
+import {api} from '@toolkit/core/api/DataApi';
 import {User} from '@toolkit/core/api/User';
 import {Updater} from '@toolkit/data/DataStore';
+import {firebaseFn} from '@toolkit/providers/firebase/client/FunctionsApi';
 import {Fave, Thing} from './DataTypes';
 
+export const GET_USER = api<void, User>('getUser', firebaseFn);
+export const UPDATE_USER = api<Updater<User>, User>('updateUser', firebaseFn);
+export const ADD_THING = api<Updater<Thing>, string>('addThing', firebaseFn);
+
 export type ThingID = string;
-export const GET_USER = createApiKey<void, User>('getUser');
-export const UPDATE_USER = createApiKey<Updater<User>, User>('updateUser');
-export const ADD_THING = createApiKey<Partial<Thing>, string>('addThing');
-export const ADD_FAVE = createApiKey<ThingID, Fave>('addFave');
-export const SEND_FAVE_NOTIF = createApiKey<Fave, void>('sendFaveNotif');
-export const SEND_THING_DELETE_NOTIF = createApiKey<string, void>(
+export const ADD_FAVE = api<ThingID, Fave>('addFave', firebaseFn);
+export const SEND_FAVE_NOTIF = api<Fave, void>('sendFaveNotif', firebaseFn);
+export const SEND_THING_DELETE_NOTIF = api<string, void>(
   'sendThingDeleteNotif',
+  firebaseFn,
 );
 
 // Admin panel
 type AdminNotifPayload = {user: User; title?: string; body: string};
-export const SEND_ADMIN_NOTIF = createApiKey<AdminNotifPayload, void>(
-  'sendAdminNotif',
-);
 
-export const BROADCAST_ADMIN_NOTIF = createApiKey<
-  Omit<AdminNotifPayload, 'user'>,
-  void
->('broadcastAdminNotif');
+export const SEND_ADMIN_NOTIF = api<AdminNotifPayload, void>(
+  'sendAdminNotif',
+  firebaseFn,
+);
+export const BROADCAST_ADMIN_NOTIF = api<Omit<AdminNotifPayload, 'user'>, void>(
+  'broadcastAdminNotif',
+  firebaseFn,
+);


### PR DESCRIPTION
Unify implementation of useData() and useApi()

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/101).
* #107
* #106
* #105
* #104
* #103
* #102
* __->__ #101
* #99
* #98
* #97