### PR TITLE
Set es5 target to fix errors on latest typescript engine

### DIFF
--- a/shell/latest/tsconfig.json
+++ b/shell/latest/tsconfig.json
@@ -21,7 +21,8 @@
     "strict": true,
     "strictPropertyInitialization": false,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "target": "es5"
   },
   "extends": "expo/tsconfig.base"
 }


### PR DESCRIPTION
Set es5 target to fix errors on latest typescript engine

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/109).
* #110
* __->__ #109