### PR TITLE
Allow passing in all firebase config options to handlers

### DIFF
--- a/lib/experimental/deletion/providers/firebase/Deletion.tsx
+++ b/lib/experimental/deletion/providers/firebase/Deletion.tsx
@@ -330,7 +330,7 @@ export const dryrunDeletion = registerHandler(
   },
   {
     allowedRoles: ['admin', 'dev'],
-    timeoutSecs: 300, // 5mins
+    timeoutSeconds: 300, // 5mins
   },
 );
 
@@ -374,6 +374,6 @@ export const dryrunRestoration = registerHandler(
   },
   {
     allowedRoles: ['admin', 'dev'],
-    timeoutSecs: 300, // 5mins
+    timeoutSeconds: 300, // 5mins
   },
 );

--- a/lib/providers/firebase/server/Handler.tsx
+++ b/lib/providers/firebase/server/Handler.tsx
@@ -98,7 +98,9 @@ export function initMiddlewares(setMiddlewares: Middleware[]) {
 // Firebase will convert all non-HttpsError errors to a generic `HttpsError{code:'internal' message:'INTERNAL'}`.
 // https://firebase.google.com/docs/functions/callable#handle_errors
 // This fn returns a new `HttpsError` with `error` converted to `CodedError` and embedded.
-const toHttpsError = function (error: Error): functions.https.HttpsError {
+export const toHttpsError = function (
+  error: Error,
+): functions.https.HttpsError {
   function newHttpsError(
     code: functions.https.FunctionsErrorCode,
     userVisibleMessage: string,
@@ -166,10 +168,7 @@ const toHttpsError = function (error: Error): functions.https.HttpsError {
  * - Setting up scope that allows us to not have to pass around a context object
  * - Running authentiacation handler
  */
-export type HandlerConfig = {
-  minInstances?: number;
-  maxInstances?: number;
-  timeoutSecs?: number;
+export type HandlerConfig = functions.RuntimeOptions & {
   allowedRoles?: Role[];
   regions?: string[];
 };
@@ -180,17 +179,7 @@ export function registerHandler<I, O>(
 ): FirebaseFunction {
   const regions = handlerConfig?.regions ?? [DEFAULT_FUNCTIONS_REGION];
 
-  const options: functions.RuntimeOptions = {
-    minInstances: handlerConfig?.minInstances,
-    maxInstances: handlerConfig?.maxInstances,
-  };
-
-  // Have to add timeout seconds to the object like this.
-  // If the `timeoutSeconds` key is set to null it's parsed as
-  // as "timeout":"undefineds"
-  if (handlerConfig?.timeoutSecs != null) {
-    options.timeoutSeconds = handlerConfig.timeoutSecs;
-  }
+  const options = handlerConfig ?? {};
 
   return functions
     .region(...regions)

--- a/lib/providers/firebase/server/Roles.tsx
+++ b/lib/providers/firebase/server/Roles.tsx
@@ -7,16 +7,25 @@
 
 import {AuthData} from 'firebase-functions/lib/common/providers/https';
 import {Role} from '@toolkit/core/api/User';
+import {Opt} from '@toolkit/core/util/Types';
 import {getAdminDataStore} from '@toolkit/providers/firebase/server/Firestore';
 import {AllowlistEntry} from '@toolkit/tbd/Allowlist';
+
+function hasValue(value: Opt<string>) {
+  return value != null && value !== '';
+}
 
 export async function getAllowlistMatchedRoles(
   auth: AuthData,
 ): Promise<Role[]> {
   const allowlistStore = getAdminDataStore(AllowlistEntry);
+  const {phone, email} = auth.token;
+
   let [phoneEntry, emailEntry] = await Promise.all([
-    allowlistStore.get(auth.token.phone ?? ''),
-    allowlistStore.get(auth.token.email ?? ''),
+    hasValue(phone) ? allowlistStore.get('allowlist:' + phone) : {roles: []},
+    hasValue(email)
+      ? allowlistStore.get('allowlist:' + email ?? '')
+      : {roles: []},
   ]);
 
   const phoneRoles = phoneEntry ? phoneEntry.roles : [];

--- a/templates/faves/server/functions/src/handlers.ts
+++ b/templates/faves/server/functions/src/handlers.ts
@@ -5,9 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as admin from 'firebase-admin';
-import * as functions from 'firebase-functions';
-import {AuthData} from 'firebase-functions/lib/common/providers/https';
+import {
+  ADD_FAVE,
+  ADD_THING,
+  BROADCAST_ADMIN_NOTIF,
+  GET_USER,
+  SEND_ADMIN_NOTIF,
+  SEND_FAVE_NOTIF,
+  SEND_THING_DELETE_NOTIF,
+  UPDATE_USER,
+} from '@app/common/Api';
+import {Fave, PROFILE_FIELDS, Thing} from '@app/common/DataTypes';
+import {NOTIF_CHANNELS} from '@app/common/NotifChannels';
 import {Profile, User, UserRoles} from '@toolkit/core/api/User';
 import {CodedError} from '@toolkit/core/util/CodedError';
 import {Updater} from '@toolkit/data/DataStore';
@@ -32,20 +41,14 @@ import {
   getSender,
 } from '@toolkit/providers/firebase/server/PushNotifications';
 import {getAllowlistMatchedRoles} from '@toolkit/providers/firebase/server/Roles';
-import {
-  ADD_FAVE,
-  ADD_THING,
-  BROADCAST_ADMIN_NOTIF,
-  GET_USER,
-  SEND_ADMIN_NOTIF,
-  SEND_FAVE_NOTIF,
-  SEND_THING_DELETE_NOTIF,
-  UPDATE_USER,
-} from '@app/common/Api';
-import {Fave, PROFILE_FIELDS, Thing} from '@app/common/DataTypes';
-import {NOTIF_CHANNELS} from '@app/common/NotifChannels';
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import {AuthData} from 'firebase-functions/lib/common/providers/https';
+const {defineSecret} = require('firebase-functions/params');
 
 const instance = getInstanceFor(getAppConfig());
+
+const notificationApiKey = defineSecret('fcm.server_key');
 
 /**
  * Convert Firebase Auth account to User
@@ -132,9 +135,9 @@ export const convertPushToken = functions.firestore
     const fcmTokenResp = Object.values(
       await apnsToFCMToken(
         change.get('sandbox')
-          ? 'com.facebook.npe.helloworld.localDevelopment'
-          : 'com.facebook.npe.helloworld',
-        functions.config().fcm.server_key,
+          ? 'com.npetoolkit.helloworld'
+          : 'com.npetoolkit.helloworld',
+        notificationApiKey.value(),
         [apnsToken],
         change.get('sandbox'),
       ),


### PR DESCRIPTION
Allow passing in all firebase config options to handlers

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/130).
* #134
* #133
* #132
* #131
* __->__ #130
* #129
* #128