### PR TITLE
Add API signature for notifcation sender

### DIFF
--- a/lib/providers/firebase/server/PushNotifications.tsx
+++ b/lib/providers/firebase/server/PushNotifications.tsx
@@ -13,6 +13,7 @@ import {CodedError} from '@toolkit/core/util/CodedError';
 import {
   NotificationsSender,
   SendPush,
+  SenderApi,
 } from '@toolkit/services/notifications/NotificationSender';
 
 /**
@@ -66,7 +67,7 @@ export const sendPush: SendPush = async (
   }
 };
 
-export const getSender = () => {
+export const getSender: () => SenderApi = () => {
   return NotificationsSender(getFirebaseNotificationsSendAPI(), {
     sendPush,
   });

--- a/lib/services/notifications/NotificationSender.tsx
+++ b/lib/services/notifications/NotificationSender.tsx
@@ -62,6 +62,15 @@ export type NotificationsProvider = {
   sendSMS?: SendSMS;
 };
 
+export type SenderApi = (
+  userIds: string | string[],
+  channel: NotificationChannel,
+  titleParams?: Record<string, string> | null,
+  bodyParams?: Record<string, string> | null,
+  data?: Record<string, string> | null,
+  badge?: string,
+) => Promise<void>;
+
 /**
  * Configures a notification sender
  *
@@ -72,7 +81,7 @@ export type NotificationsProvider = {
 export const NotificationsSender = (
   notifSendAPI: NotificationsSendAPI,
   provider: NotificationsProvider,
-) => {
+): SenderApi => {
   const {getPreferredSendDestinations} = notifSendAPI;
   const {sendPush, sendEmail, sendSMS} = provider;
 


### PR DESCRIPTION
Add API signature for notifcation sender

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/135).
* #143
* #142
* #141
* #140
* #139
* #138
* #137
* #136
* __->__ #135