### PR TITLE
Default API signatures as void

### DIFF
--- a/lib/core/api/DataApi.tsx
+++ b/lib/core/api/DataApi.tsx
@@ -85,7 +85,7 @@ export function useApi<I, O>(key: ApiKey<I, O>): Api<I, O> {
  *   iterations of the app and in local testing for client-only development:
  *   `api<string, void>(key, firebaseFn, (in: string) => {...})
  */
-export function api<I, O>(
+export function api<I = void, O = void>(
   id: string,
   fn: UseApi<I, O>,
   client?: UseApi<I, O>,
@@ -101,7 +101,10 @@ export function api<I, O>(
 /**
  * Create an API using the default server API implementation for the app.
  */
-export function serverApi<I, O>(id: string, client?: UseApi<I, O>) {
+export function serverApi<I = void, O = void>(
+  id: string,
+  client?: UseApi<I, O>,
+) {
   return api(id, useDefaultServerApi, client);
 }
 

--- a/lib/providers/firebase/server/PushNotifications.tsx
+++ b/lib/providers/firebase/server/PushNotifications.tsx
@@ -13,6 +13,7 @@ import {CodedError} from '@toolkit/core/util/CodedError';
 import {
   NotificationsSender,
   SendPush,
+  SenderApi,
 } from '@toolkit/services/notifications/NotificationSender';
 
 /**
@@ -66,7 +67,7 @@ export const sendPush: SendPush = async (
   }
 };
 
-export const getSender = () => {
+export const getSender: () => SenderApi = () => {
   return NotificationsSender(getFirebaseNotificationsSendAPI(), {
     sendPush,
   });

--- a/lib/services/notifications/NotificationSender.tsx
+++ b/lib/services/notifications/NotificationSender.tsx
@@ -62,6 +62,15 @@ export type NotificationsProvider = {
   sendSMS?: SendSMS;
 };
 
+export type SenderApi = (
+  userIds: string | string[],
+  channel: NotificationChannel,
+  titleParams?: Record<string, string> | null,
+  bodyParams?: Record<string, string> | null,
+  data?: Record<string, string> | null,
+  badge?: string,
+) => Promise<void>;
+
 /**
  * Configures a notification sender
  *
@@ -72,7 +81,7 @@ export type NotificationsProvider = {
 export const NotificationsSender = (
   notifSendAPI: NotificationsSendAPI,
   provider: NotificationsProvider,
-) => {
+): SenderApi => {
   const {getPreferredSendDestinations} = notifSendAPI;
   const {sendPush, sendEmail, sendSMS} = provider;
 


### PR DESCRIPTION
Default API signatures as void

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/136).
* #143
* #142
* #141
* #140
* #139
* #138
* #137
* __->__ #136
* #135