### PR TITLE
Update <Icon> to officially allow `style` prop

### DIFF
--- a/docs/release/tos.md
+++ b/docs/release/tos.md
@@ -1,0 +1,15 @@
+# Terms of Service
+
+One of the steps you need to take to release your app is to have terms of
+service that are linked to and shown in appropriate places in your app.
+
+Please get legal advice before launching.
+
+Users who sign up with a given set of terms can't easily have them changed, and
+the TOS can impact your ability to email or SMS your customers, display ads,
+share data with third party service providers, and more.
+
+Early applications commonly link to the TOS from the login screen and from
+Settings (this is the default in Toolit sample apps), and you can find services
+that will help generate your Terms of Service - here's the
+[Google Link](https://www.google.com/search?q=terms+of+service+genrator).

--- a/lib/core/api/DataApi.tsx
+++ b/lib/core/api/DataApi.tsx
@@ -85,7 +85,7 @@ export function useApi<I, O>(key: ApiKey<I, O>): Api<I, O> {
  *   iterations of the app and in local testing for client-only development:
  *   `api<string, void>(key, firebaseFn, (in: string) => {...})
  */
-export function api<I, O>(
+export function api<I = void, O = void>(
   id: string,
   fn: UseApi<I, O>,
   client?: UseApi<I, O>,
@@ -101,7 +101,10 @@ export function api<I, O>(
 /**
  * Create an API using the default server API implementation for the app.
  */
-export function serverApi<I, O>(id: string, client?: UseApi<I, O>) {
+export function serverApi<I = void, O = void>(
+  id: string,
+  client?: UseApi<I, O>,
+) {
   return api(id, useDefaultServerApi, client);
 }
 

--- a/lib/providers/firebase/server/PushNotifications.tsx
+++ b/lib/providers/firebase/server/PushNotifications.tsx
@@ -13,6 +13,7 @@ import {CodedError} from '@toolkit/core/util/CodedError';
 import {
   NotificationsSender,
   SendPush,
+  SenderApi,
 } from '@toolkit/services/notifications/NotificationSender';
 
 /**
@@ -66,7 +67,7 @@ export const sendPush: SendPush = async (
   }
 };
 
-export const getSender = () => {
+export const getSender: () => SenderApi = () => {
   return NotificationsSender(getFirebaseNotificationsSendAPI(), {
     sendPush,
   });

--- a/lib/screens/Settings.tsx
+++ b/lib/screens/Settings.tsx
@@ -7,8 +7,8 @@
 
 import React from 'react';
 import {StyleSheet, Text, TouchableOpacity, View} from 'react-native';
-import {MaterialCommunityIcons as Icon} from '@expo/vector-icons';
 import {ActionItem, useAction} from '@toolkit/core/client/Action';
+import {Icon} from '@toolkit/ui/components/Icon';
 import {Screen} from '@toolkit/ui/screen/Screen';
 
 export type Setting = ActionItem | string;
@@ -47,11 +47,9 @@ const SettingsItem = (props: SettingsItemProps) => {
   return (
     <TouchableOpacity style={S.itemRow} onPress={handler}>
       {item.icon != null && (
-        <Icon /* @ts-ignore */
-          name={item.icon}
-          size={28}
-          style={{opacity: 0.65, marginRight: 16, width: 28}}
-        />
+        <View style={S.iconBox}>
+          <Icon name={item.icon} size={28} style={{opacity: 0.65, width: 28}} />
+        </View>
       )}
       <Text style={S.itemTitle}>{item.label}</Text>
       {info && <Text style={S.itemInfo}>{info}</Text>}
@@ -89,6 +87,11 @@ const S = StyleSheet.create({
     opacity: 0.7,
     marginTop: 32,
     marginBottom: 8,
+  },
+  iconBox: {
+    width: 28,
+    height: 28,
+    marginRight: 16,
   },
 });
 

--- a/lib/screens/settings/NotificationSettings.tsx
+++ b/lib/screens/settings/NotificationSettings.tsx
@@ -163,7 +163,8 @@ export const NotificationSettingsScreen: Screen<Props> = props => {
 };
 
 NotificationSettingsScreen.title = 'Notifications';
-NotificationSettingsScreen.load = async props => {
+
+NotificationSettingsScreen.load = async () => {
   const {getNotificationPrefs} = useNotifications();
   const channels = useNotificationChannels();
   const promises = Object.values(channels).map(async channel => {

--- a/lib/services/notifications/NotificationSender.tsx
+++ b/lib/services/notifications/NotificationSender.tsx
@@ -62,6 +62,15 @@ export type NotificationsProvider = {
   sendSMS?: SendSMS;
 };
 
+export type SenderApi = (
+  userIds: string | string[],
+  channel: NotificationChannel,
+  titleParams?: Record<string, string> | null,
+  bodyParams?: Record<string, string> | null,
+  data?: Record<string, string> | null,
+  badge?: string,
+) => Promise<void>;
+
 /**
  * Configures a notification sender
  *
@@ -72,7 +81,7 @@ export type NotificationsProvider = {
 export const NotificationsSender = (
   notifSendAPI: NotificationsSendAPI,
   provider: NotificationsProvider,
-) => {
+): SenderApi => {
   const {getPreferredSendDestinations} = notifSendAPI;
   const {sendPush, sendEmail, sendSMS} = provider;
 

--- a/lib/ui/components/Icon.tsx
+++ b/lib/ui/components/Icon.tsx
@@ -6,11 +6,13 @@
  */
 
 import React from 'react';
-import {Image, ImageSourcePropType} from 'react-native';
+import {Image, ImageSourcePropType, StyleProp, ViewStyle} from 'react-native';
 import {useTheme} from 'react-native-paper';
-import {IconProps} from 'react-native-paper/lib/typescript/components/MaterialCommunityIcon';
+import {IconProps as ExpoIconProps} from 'react-native-paper/lib/typescript/components/MaterialCommunityIcon';
 
-/**
+type IconProps = Partial<ExpoIconProps> & {style?: StyleProp<ViewStyle>};
+
+/*
  * Utility to load icons by name.
  *
  * Name is of form "prefix:localName". Prefixes are
@@ -20,7 +22,6 @@ import {IconProps} from 'react-native-paper/lib/typescript/components/MaterialCo
  * To register an icon font library:
  * ```
  * import {Ionicons} from '@expo/vector-icons';
- *
  * registerIconProvider('ion', Ionicons);
  * ```
  *
@@ -35,7 +36,7 @@ import {IconProps} from 'react-native-paper/lib/typescript/components/MaterialCo
  * <IconButton name="image:loop" onPress={doSomething}/>
  * ```
  */
-export const Icon = (props: Partial<IconProps>) => {
+export const Icon = (props: IconProps) => {
   const {name = '', color, ...rest} = props;
 
   // Split into prefix and localName within that icon namespace


### PR DESCRIPTION
Update <Icon> to officially allow `style` prop

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/140).
* #143
* #142
* #141
* __->__ #140
* #139
* #138
* #137
* #136
* #135