### PR TITLE
Utility for one-off errors for user messages

### DIFF
--- a/lib/core/client/Action.tsx
+++ b/lib/core/client/Action.tsx
@@ -188,6 +188,7 @@ export function useActionImpl<I extends ARGS, O>(
       setError(undefined);
       return await withTimeout(() => handler(...args), timeout);
     } catch (e: any) {
+      console.error(e);
       setError(e as Error);
       throw e;
     } finally {

--- a/lib/core/util/CodedError.tsx
+++ b/lib/core/util/CodedError.tsx
@@ -67,3 +67,13 @@ export function toUserMessage(error: any, defaultText?: string) {
     ? error.userVisibleMessage
     : defaultText ?? DEFAULT_ERROR_TEXT;
 }
+
+/**
+ * Throw an ad-hoc error with a generic error code user visible message.
+ *
+ * These can't be aggregated as cleanly, so don't use for common or expected errors
+ * as it will be more difficult to distinguish the call site.
+ */
+export function AdhocError(msg: string) {
+  return new CodedError('npe.adhoc', msg, msg);
+}


### PR DESCRIPTION
Utility for one-off errors for user messages

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/145).
* #154
* #153
* #152
* #151
* #150
* #149
* #148
* #147
* #146
* __->__ #145
* #144