### PR TITLE
Remove invalid call to `replaceAll()`

### DIFF
--- a/lib/core/api/Log.tsx
+++ b/lib/core/api/Log.tsx
@@ -70,7 +70,8 @@ export function useLogPromise<T>(): (
       if (e instanceof CodedError) {
         event.statusCode = e.type;
       }
-      event.debug = e?.message + '\n' + e?.stack;
+      event.errMsg = e.message;
+      event.stack = e?.stack;
     } finally {
       event.duration = Date.now() - event.when!;
     }
@@ -111,7 +112,7 @@ setContextDefault(LOG_CONTEXT_KEY, NULL_LOGGER);
  * Logger that stores the last 500 log events in memory,
  * for display in developer tools.
  */
-function DevLogger() {
+export function DevLogger() {
   return (event: LogEvent) => {
     DEV_LOG_EVENTS.push(event);
     if (DEV_LOG_EVENTS.length > MAX_DEV_LOG_EVENTS) {
@@ -136,7 +137,7 @@ export function ConsoleLogger() {
     if (__DEV__) {
       const eventStr = eventToString(event);
       if (event.status === 'error') {
-        console.error(`[Error] ${eventStr}`, `[Details] ${event.debug}`);
+        console.error(`[Error] ${eventStr}`);
       } else {
         console.log(`[Log] ${eventStr}`);
       }
@@ -187,7 +188,7 @@ function useCreateLogEvent(): (name: string) => LogEvent {
   });
 }
 
-function eventToString(event: LogEvent) {
+export function eventToString(event: LogEvent) {
   let str = (event.where != null ? event.where + '::' : '') + event.name;
 
   if (event.when) {
@@ -198,14 +199,14 @@ function eventToString(event: LogEvent) {
   if (event.duration != null) {
     str += `, Duration Ms: ${event.duration}`;
   }
-  if (event.user) {
-    str += ', Has User';
-  }
 
   if (event.status !== 'ok') {
     str += `, Status: ${event.status}`;
     if (event.statusCode != null) {
       str += ` [${event.statusCode}]`;
+    }
+    if (event.errMsg != null) {
+      str += `, ${event.errMsg}`;
     }
   }
 
@@ -269,8 +270,11 @@ type LogEvent = {
   /** Status code, for more information on error status results */
   statusCode?: string;
 
-  /** Debug information, including full stack trace */
-  debug?: string;
+  /** Error message, when available */
+  errMsg?: string;
+
+  /** Full stack trace, when available */
+  stack?: string;
 
   /** Platform from which this request came */
   platform?: typeof Platform.OS | 'server';

--- a/lib/core/api/Log.tsx
+++ b/lib/core/api/Log.tsx
@@ -5,48 +5,141 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Common, cross-platform utilties for NPE logging. Other files are platform-specific
-
+import * as React from 'react';
+import {Platform} from 'react-native';
+import {useLoggedInUser} from '@toolkit/core/api/User';
 import {
   context,
   contextKey,
   setContextDefault,
   useAppContext,
 } from '@toolkit/core/util/AppContext';
+import {CodedError} from '@toolkit/core/util/CodedError';
 
-// These are the fields that client is currently allowed to set.
-// Event is kept as a separate, top-level param
-export type ClientLogParams = {
-  duration?: string;
-  end_state?: string;
-  end_state_code?: string;
-  debug_info?: string;
-};
+/**
+ * For logging events, most clients should use either:
+ * - `useLogEvent()` to log a single event at a point in time, or
+ * - `useAction()` to log an async action (this includes other cross-cutting functionatily)
+ * - `useLogPromise()` to log a promise when the Action API isn't suitable
+ *
+ * For configuring logging:
+ * - Most apps will start using the `DevLogger` in their templates, which gives access to
+ *   the log events in developer tools
+ * - For production, there will be different options to log to the server,
+ *   depending on what systems you are using to report your analytics
+ */
 
-// TODO: Default!
-export const LOG_CONTEXT_KEY =
-  contextKey<UseLogApi<ClientLogParams>>('core.log');
+/**
+ * Simplest way to log an event, can use just a string.
+ * The rest of the event payload will be inferred by the context.
+ *
+ * This is useful for events that are a single point in time - for
+ * async actions, use `useLogPromise()`
+ */
+export function useLogEvent(): (name: string) => void {
+  const createLogEvent = useCreateLogEvent();
+  const logger = useLogApi();
 
-export type LogApi<T> = (event: string, params?: T) => void;
-export type UseLogApi<T> = () => LogApi<T>;
+  return (name: string, where?: string) => {
+    const event = createLogEvent(name);
+    if (where != null) event.where = where;
+    logger(event);
+  };
+}
 
-// Use system defined log event service
-export function useLogEvent(): LogApi<ClientLogParams> {
+/**
+ * Create a log entry for a promise.
+ * - Duration will be set for the duration of the promise
+ * - status will be set based on the success or failure of the promise
+ * - If promise is an error, debug will be set to the error stack.
+ */
+export function useLogPromise<T>(): (
+  promise: Promise<T>,
+  name: string,
+) => void {
+  const createLogEvent = useCreateLogEvent();
+  const logger = useLogApi();
+
+  return async (promise: Promise<T>, name: string) => {
+    const event = createLogEvent(name);
+
+    try {
+      await promise;
+    } catch (e: any) {
+      event.status = 'error';
+      if (e instanceof CodedError) {
+        event.statusCode = e.type;
+      }
+      event.debug = e?.message + '\n' + e?.stack;
+    } finally {
+      event.duration = Date.now() - event.when!;
+    }
+
+    logger(event);
+  };
+}
+
+/**
+ * Type and context for a lower level event logger.
+ */
+type LogApi = (event: LogEvent) => void | Promise<void>;
+type UseLogApi = () => LogApi;
+export const LOG_CONTEXT_KEY = contextKey<UseLogApi>('core.log');
+
+/**
+ * Get the low level event logger. Most clients should *not* use this API directly,
+ * as there are a large set of fields that need to be filled in, and the higher
+ * level logging apis will do this automatically for you
+ */
+export function useLogApi(): LogApi {
   const useLogEventImpl = useAppContext(LOG_CONTEXT_KEY);
   const logEvent = useLogEventImpl();
   return logEvent;
 }
 
+/**
+ * Default logger - does nothing.
+ */
 function NullLogger() {
-  return (_event: string, _payload?: any) => {};
+  return () => {};
 }
+
 export const NULL_LOGGER = context(LOG_CONTEXT_KEY, NullLogger);
 setContextDefault(LOG_CONTEXT_KEY, NULL_LOGGER);
 
+/**
+ * Logger that stores the last 500 log events in memory,
+ * for display in developer tools.
+ */
+function DevLogger() {
+  return (event: LogEvent) => {
+    DEV_LOG_EVENTS.push(event);
+    if (DEV_LOG_EVENTS.length > MAX_DEV_LOG_EVENTS) {
+      DEV_LOG_EVENTS.shift();
+    }
+  };
+}
+export function getDevLogs() {
+  return DEV_LOG_EVENTS;
+}
+
+const DEV_LOG_EVENTS: LogEvent[] = [];
+const MAX_DEV_LOG_EVENTS = 500;
+
+export const DEV_LOGGER = context(LOG_CONTEXT_KEY, DevLogger);
+
+/**
+ * Logger that writes to console.log
+ */
 export function ConsoleLogger() {
-  return (event: string, payload?: any) => {
+  return (event: LogEvent) => {
     if (__DEV__) {
-      console.log(`LogEvent: ${event}`, payload ?? '');
+      const eventStr = eventToString(event);
+      if (event.status === 'error') {
+        console.error(`[Error] ${eventStr}`, `[Details] ${event.debug}`);
+      } else {
+        console.log(`[Log] ${eventStr}`);
+      }
     }
   };
 }
@@ -56,12 +149,12 @@ export const CONSOLE_LOGGER = context(LOG_CONTEXT_KEY, ConsoleLogger);
  * Log to multiple sources. All of the loggers must support the same log payload,
  * or allow for `any` payloads.
  */
-export function multiLogger<T>(useLogApis: UseLogApi<T>[]): UseLogApi<T> {
+export function multiLogger<T>(useLogApis: UseLogApi[]): UseLogApi {
   return () => {
     const logEvents = useLogApis.map(useLogApi => useLogApi());
-    return (event: string, params?: T) => {
+    return (event: LogEvent) => {
       try {
-        logEvents.forEach(logEvent => logEvent(event, params));
+        logEvents.forEach(logEvent => logEvent(event));
       } catch (e) {
         console.error(e);
       }
@@ -70,12 +163,122 @@ export function multiLogger<T>(useLogApis: UseLogApi<T>[]): UseLogApi<T> {
 }
 
 /**
- * Convience wrapper to create a`MultiLogger<ClientLogParams>` context
+ * Convience wrapper to create a`MultiLogger` from a list of loggers.
  */
-export function MultiLogger(useLogApis: UseLogApi<ClientLogParams>[]) {
+export function MultiLogger(useLogApis: UseLogApi[]) {
   return context(LOG_CONTEXT_KEY, multiLogger(useLogApis));
 }
 
-export function eventFromCamelCase(event: string): string {
-  return event.replace(/([a-z])([A-Z])/, '$1_$2').toUpperCase();
+function useCreateLogEvent(): (name: string) => LogEvent {
+  // Ideally we want the version here that doesn't throw at startup. Hmm
+  const user = useLoggedInUser();
+  const {where} = useCallerId();
+  //console.log('where', where);
+
+  // TODO: Get where from navigation
+  // TODO: Get user from auth
+  return (name: string) => ({
+    user: user?.id,
+    name,
+    where,
+    when: Date.now(),
+    status: 'ok',
+    platform: Platform.OS,
+  });
 }
+
+function eventToString(event: LogEvent) {
+  let str = (event.where != null ? event.where + '::' : '') + event.name;
+
+  if (event.when) {
+    const d = new Date(event.when);
+    const date = d.toLocaleString('en-US', {hour12: false}).replace(', ', '.');
+    str += ` @${date}.${d.getMilliseconds()}`;
+  }
+  if (event.duration != null) {
+    str += `, Duration Ms: ${event.duration}`;
+  }
+  if (event.user) {
+    str += ', Has User';
+  }
+
+  if (event.status !== 'ok') {
+    str += `, Status: ${event.status}`;
+    if (event.statusCode != null) {
+      str += ` [${event.statusCode}]`;
+    }
+  }
+
+  return str;
+}
+
+/**
+ * Logged events need to be associated with a place from which they were initiated.
+ * This the name of a screen, a background process, or a server API endpoint.
+ *
+ * To allow logging from lower-level code that doesn't direct access to this information,
+ * we are providing it via context.
+ *
+ * This uses `React.Context` instead of `AppContext` as there will be different
+ * values per screen in the app. `AppContext` is for app-global values that
+ * change infrequently.
+ *
+ * This may be useful for use cases beyond logging (e.g. rate limiting API calls separately
+ * based on which screen called then).
+ */
+type CallerId = {
+  where: string;
+};
+
+/**
+ * Default context is an app-level context. This is needed for logging events
+ * that occur outside of the context of any specific screen.
+ */
+export const CallerIdContext = React.createContext<CallerId>({
+  where: 'App',
+});
+
+export function useCallerId(): CallerId {
+  return React.useContext(CallerIdContext);
+}
+
+/**
+ * Low level event payload for sending log even data to logging systems.
+ *
+ * Most clients will only interact with a small set of these fields directly.
+ */
+type LogEvent = {
+  /** ID of the user at device or for whose data this is being executed */
+  user?: string;
+
+  /** Event name */
+  name: string;
+
+  /** Where in the app the event took place. Can be a screen, or a logical background or server process */
+  where?: string;
+
+  /** When the event occurred */
+  when?: number;
+
+  /** Duration of the event. Will default to time event is processed if not set */
+  duration?: number;
+
+  /** Status of the event, defaults to 'ok' */
+  status?: 'ok' | 'timeout' | 'error' | 'cancelled';
+
+  /** Status code, for more information on error status results */
+  statusCode?: string;
+
+  /** Debug information, including full stack trace */
+  debug?: string;
+
+  /** Platform from which this request came */
+  platform?: typeof Platform.OS | 'server';
+
+  /*
+  To add:
+  - session
+  - source
+  - deviceType
+   */
+};

--- a/lib/providers/navigation/ReactNavigation.tsx
+++ b/lib/providers/navigation/ReactNavigation.tsx
@@ -14,46 +14,16 @@ import {
   useRoute,
 } from '@react-navigation/core';
 import {
-  NavigationState,
   StackActions,
   getPathFromState as getPathFromStateInternal,
   useNavigation,
 } from '@react-navigation/native';
-import {eventFromCamelCase, useLogEvent} from '@toolkit/core/api/Log';
 import {setInitialAppContext} from '@toolkit/core/util/AppContext';
 import {PropsFor} from '@toolkit/core/util/Loadable';
 import {Opt} from '@toolkit/core/util/Types';
 import {ApplyLayout, LayoutComponent} from '@toolkit/ui/screen/Layout';
 import {NAV_CONTEXT_KEY, NAV_STATE_KEY, Routes} from '@toolkit/ui/screen/Nav';
 import {Screen, ScreenType} from '@toolkit/ui/screen/Screen';
-
-/**
- * Utiltiy for logging all page transitiions in react-navigation.
- *
- * Usage:
- * ```
- * const navLogger = useReactNavigationLogger();
- * ...
- * <NavigationContainer onStateChange={navLogger}>
- *   ...
- * </NavigationContainer>
- */
-export function useReactNavigationLogger() {
-  const lastRoute = React.useRef<string | undefined>();
-  const logEvent = useLogEvent();
-
-  function onNavStateChange(state: NavigationState | undefined) {
-    const route = state?.routes[state?.index ?? 0]?.name;
-    if (route !== lastRoute.current) {
-      lastRoute.current = route;
-      if (route != null) {
-        logEvent('VIEW_' + eventFromCamelCase(route));
-      }
-    }
-  }
-
-  return onNavStateChange;
-}
 
 const DEFAULT_SCREEN_OPTIONS = {
   modal: {presentation: Platform.OS === 'web' ? 'transparentModal' : 'modal'},

--- a/lib/screens/admin/Allowlist.tsx
+++ b/lib/screens/admin/Allowlist.tsx
@@ -31,7 +31,7 @@ const AllowlistScreen: Screen<Props> = ({async: {entries}}: Props) => {
   const {navTo} = useNav();
   const allowlistStoreNew = useDataStore(AllowlistEntry);
   const reload = useReload();
-  const [onDelete] = useAction(deleteEntry);
+  const [onDelete] = useAction('AllowlistDelete', deleteEntry);
   const {Body} = useComponents();
 
   async function deleteEntry(entry: AllowlistEntry) {

--- a/lib/screens/admin/AllowlistEdit.tsx
+++ b/lib/screens/admin/AllowlistEdit.tsx
@@ -33,7 +33,7 @@ const AllowlistEdit: Screen<Props> = (props: Props) => {
   const {Subtitle, Button} = useComponents();
   const [UserKeyInput, userKey] = useTextInput(formatKey(entry?.userKey ?? ''));
   const [roles, setRoles] = React.useState(entry?.roles ?? []);
-  const [onSave, saving] = useAction(save);
+  const [onSave, saving] = useAction('AllowlistSave', save);
   const allowlistStore = useDataStore(AllowlistEntry);
 
   const title = entry ? 'Edit Allowlist Entry' : 'New Allowlist Entry';

--- a/lib/screens/login/LoginScreen.tsx
+++ b/lib/screens/login/LoginScreen.tsx
@@ -108,7 +108,7 @@ export function AuthenticationButtons(props: {
   const tryFacebookLogin = auth.useTryConnect('facebook', FB_SCOPES);
   const tryGoogleLogin = auth.useTryConnect('google', GOOGLE_SCOPES);
   const {Body, Error} = useComponents();
-  const [tryLoginAction, loggingIn] = useAction(tryLogin);
+  const [tryLoginAction, loggingIn] = useAction('TryLogin', tryLogin);
 
   async function tryLogin(type: AuthType): Promise<void> {
     setLoginErrorMessage(null);

--- a/lib/ui/components/MultistepFlow.tsx
+++ b/lib/ui/components/MultistepFlow.tsx
@@ -192,7 +192,7 @@ export function Step(props: StepProps) {
   const flow = useFlow();
   const {top} = useSafeAreaInsets();
   const {Button, Body, Title} = useComponents();
-  const [onNextStep, loading] = useAction(nextStep);
+  const [onNextStep, loading] = useAction('NextStep:', nextStep);
 
   async function nextStep() {
     if (onNext) {

--- a/lib/ui/components/MultistepFlow.tsx
+++ b/lib/ui/components/MultistepFlow.tsx
@@ -7,9 +7,11 @@
 
 import React, {useContext} from 'react';
 import {
+  Keyboard,
   KeyboardAvoidingView,
   LayoutAnimation,
   LayoutAnimationConfig,
+  Platform,
   ScrollView,
   StyleSheet,
   View,
@@ -197,6 +199,7 @@ export function Step(props: StepProps) {
       await onNext();
     }
     await flow.next();
+    Keyboard.dismiss();
   }
 
   async function skip() {
@@ -204,6 +207,7 @@ export function Step(props: StepProps) {
       await onSkip();
     }
     await flow.next();
+    Keyboard.dismiss();
   }
   const skippy = React.useCallback(skip, [onSkip, flow]);
 
@@ -213,9 +217,9 @@ export function Step(props: StepProps) {
   return (
     <KeyboardAvoidingView
       style={S.containerRoot}
-      behavior={'padding'}
+      behavior={Platform.OS === 'android' ? 'height' : 'padding'}
       keyboardVerticalOffset={top}>
-      <SafeAreaView style={[S.container]}>
+      <View style={[S.container]}>
         <KeyboardDismissPressable />
         <LoginFlowBackButton back={flow.back} />
 
@@ -240,7 +244,7 @@ export function Step(props: StepProps) {
             </Button>
           </View>
         </View>
-      </SafeAreaView>
+      </View>
     </KeyboardAvoidingView>
   );
 }

--- a/lib/ui/layout/DrawerLayout.tsx
+++ b/lib/ui/layout/DrawerLayout.tsx
@@ -202,10 +202,10 @@ const GO_BACK = {
 
 function AppBarAction(props: {item: ActionItem; color: string}) {
   const {
-    item: {icon, label, action},
+    item: {id, icon, label, action},
     color,
   } = props;
-  const [handler] = useAction(action);
+  const [handler] = useAction(id, action);
 
   if (icon == null) {
     return <></>;
@@ -356,7 +356,7 @@ type ActionFABProps = WithoutIcon & {item: ActionItem; icon?: string};
 function ActionFAB(props: ActionFABProps) {
   const {item, icon, ...fabProps} = props;
 
-  const [handler] = useAction(item.action);
+  const [handler] = useAction(item.id, item.action);
   const iconSpec = item.icon || icon;
 
   if (!iconSpec) {
@@ -375,7 +375,7 @@ type ActionMenuProps = {
 const ActionMenu = (props: ActionMenuProps) => {
   const {size = 18, color, items} = props;
   const handlers = items.map(item => {
-    const [handler] = useAction(item.action);
+    const [handler] = useAction(item.id, item.action);
     return handler;
   });
   const [menuVisible, setMenuVisible] = React.useState(false);

--- a/lib/ui/layout/LayoutSelector.tsx
+++ b/lib/ui/layout/LayoutSelector.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import {useRoute} from '@react-navigation/core';
 import {useNavigation} from '@react-navigation/native';
 import {canLoggingInFix} from '@toolkit/core/api/Auth';
-import {eventFromCamelCase, useLogEvent} from '@toolkit/core/api/Log';
+import {useLogEvent} from '@toolkit/core/api/Log';
 import {useUserMessaging} from '@toolkit/core/client/Status';
 import {deviceIsMobile} from '@toolkit/core/util/Environment';
 import {LayoutComponent, LayoutProps} from '@toolkit/ui/screen/Layout';
@@ -43,7 +43,7 @@ const LayoutSelector = (props: Layouts & LayoutProps) => {
     // Clear user messages when navigating
     const unsubscribe = reactNav.addListener('focus', () => {
       userMessaging.clear();
-      logEvent(eventNameFromScreen(route.name));
+      logEvent('View');
     });
 
     return unsubscribe;
@@ -70,7 +70,3 @@ const LayoutSelector = (props: Layouts & LayoutProps) => {
 
   return <Layout {...props} onError={onError} />;
 };
-
-function eventNameFromScreen(screen: string) {
-  return 'VIEW_' + eventFromCamelCase(screen.replace('Screen', ''));
-}

--- a/lib/ui/screen/Layout.tsx
+++ b/lib/ui/screen/Layout.tsx
@@ -7,6 +7,7 @@
 
 import * as React from 'react';
 import {Text} from 'react-native';
+import {CallerIdContext} from '@toolkit/core/api/Log';
 import {ErrorHandler} from '@toolkit/core/client/TriState';
 import {
   contextKey,
@@ -15,6 +16,7 @@ import {
 } from '@toolkit/core/util/AppContext';
 import {PropsFor, useAsyncLoad} from '@toolkit/core/util/Loadable';
 import {Screen, ScreenProps} from '@toolkit/ui/screen/Screen';
+import {useNavState} from './Nav';
 
 export type LayoutProps = ScreenProps & {
   children?: React.ReactNode;
@@ -42,6 +44,7 @@ export function ApplyLayout<S extends Screen<any>>(props: Props<S>) {
   const [screenProps, setScreenProps] =
     React.useState<ScreenProps>(baseScreenProps);
   const Component = useAsyncLoad(screen);
+  const {location} = useNavState();
 
   const getScreenState = () => {
     return screenProps;
@@ -63,15 +66,18 @@ export function ApplyLayout<S extends Screen<any>>(props: Props<S>) {
   const api = {getScreenState, setScreenState};
 
   setInitialAppContext(SCREEN_API_KEY, api);
+  const callerId = {where: location.route ?? 'Unknown'};
 
   return (
-    <Layout {...screenProps}>
-      {Component ? (
-        <Component {...params} />
-      ) : (
-        <Text>No Screen for "[location.route]"</Text>
-      )}
-    </Layout>
+    <CallerIdContext.Provider value={callerId}>
+      <Layout {...screenProps}>
+        {Component ? (
+          <Component {...params} />
+        ) : (
+          <Text>No Screen for ${location.route}</Text>
+        )}
+      </Layout>
+    </CallerIdContext.Provider>
   );
 }
 

--- a/lib/ui/screen/Nav.tsx
+++ b/lib/ui/screen/Nav.tsx
@@ -105,7 +105,7 @@ export function navToAction(spec: NavSpec): ActionItem {
   const {to, label, icon, params} = spec;
 
   const screen = 'getScreen' in to ? to.getScreen() : to;
-  const id = `NavTo${screen.displayName ?? label.replaceAll(' ', '')}`;
+  const id = `NavTo${screen.displayName ?? label.replace(/ /g, '')}`;
 
   return {
     id,

--- a/lib/ui/screen/Nav.tsx
+++ b/lib/ui/screen/Nav.tsx
@@ -105,7 +105,7 @@ export function navToAction(spec: NavSpec): ActionItem {
   const {to, label, icon, params} = spec;
 
   const screen = 'getScreen' in to ? to.getScreen() : to;
-  const id = (screen.displayName ?? label).toUpperCase();
+  const id = `NavTo${screen.displayName ?? label.replaceAll(' ', '')}`;
 
   return {
     id,


### PR DESCRIPTION
Remove invalid call to `replaceAll()`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/npe-toolkit/pull/169).
* #173
* #172
* #171
* #170
* __->__ #169
* #168
* #167
* #166
* #165
* #164